### PR TITLE
Fix Contact 'email' property filtered due to 'Emails' HubSpot type

### DIFF
--- a/src/Api/Model.php
+++ b/src/Api/Model.php
@@ -81,13 +81,19 @@ abstract class Model
 
         $properties = array_filter(
             $properties,
-            static fn (string $key): bool => !(HubSpot::isType($key) || HubSpot::isType(Str::plural($key))),
+            fn (string $key): bool => $this->isAllowedProperty($key),
             ARRAY_FILTER_USE_KEY
         );
 
         $this->properties = array_merge($this->properties, $properties);
 
         return $this;
+    }
+
+    private function isAllowedProperty(string $key): bool
+    {
+        return $key === 'email' || 
+               !(HubSpot::isType($key) || HubSpot::isType(Str::plural($key)));
     }
 
     public function type(): string
@@ -249,10 +255,9 @@ abstract class Model
 
     public function __set($key, $value)
     {
-        if (HubSpot::isType($key) || HubSpot::isType(Str::plural($key))) {
-            return;
+        if ($this->isAllowedProperty($key)) {
+            $this->properties[$key] = $value;
         }
-        $this->properties[$key] = $value;
     }
 
     public function __isset($key)


### PR DESCRIPTION
This PR addresses an issue where the 'email' property was being incorrectly filtered out due to a conflict with the 'Emails' HubSpot type. This was causing a "sales-email-read" scope error when attempting to access $contact->email, as the code was inadvertently trying to access the $contact->emails associated type instead.

Changes:
- Added an `isAllowedProperty` method to centralize property filtering logic
- Updated `fill` and `__set` methods to use `isAllowedProperty`
- Specifically allowed 'email' property while maintaining filtering for other HubSpot types

This fix ensures that:
1. The 'email' property is correctly retained and accessible
2. The code no longer attempts to access the 'Emails' associated type when simply trying to get the email property from a Contact
3. The "sales-email-read" scope error is avoided for email property access

The original intent of filtering out most HubSpot types is maintained, while solving this specific edge case.

This change should resolve issues for users who were encountering unexpected scope errors when working with contact email addresses.

Please let me know if you need any further information or changes.